### PR TITLE
fix: address clippy::unnecessary_unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::declare_interior_mutable_const, clippy::borrow_interior_mutable_const, clippy::unnecessary_unwrap, clippy::module_inception, clippy::result_large_err, clippy::type_complexity, clippy::upper_case_acronyms, clippy::wrong_self_convention)]
+#![allow(clippy::declare_interior_mutable_const, clippy::borrow_interior_mutable_const, clippy::module_inception, clippy::result_large_err, clippy::type_complexity, clippy::upper_case_acronyms, clippy::wrong_self_convention)]
 mod kvstore;
 mod package_db;
 mod prelude;

--- a/src/package_db/http/http.rs
+++ b/src/package_db/http/http.rs
@@ -343,6 +343,13 @@ impl HttpInner {
     ) -> Result<Box<dyn ReadPlusSeek>> {
         let request = http::Request::builder().uri(url.as_str()).body(())?;
         if maybe_hash.is_some() && cache_mode != CacheMode::NoStore {
+            // Since `maybe_hash` is checked for non-None value in the previous
+            // conditional, clippy complains that you shouldn't need to unwrap.
+            // The resulting code to make clippy happy is less clear than this
+            // code, and using `if let Some(maybe_hash)` with `&&` is currently
+            // unstable. Prefer clarity of code over linting, but if this
+            // logic changes, please try to address this exception.
+            #[allow(clippy::unnecessary_unwrap)]
             let hash = maybe_hash.unwrap();
             if cache_mode == CacheMode::OnlyIfCached {
                 self.hash_cache.get(&hash).ok_or_else(||NotCached {}.into())


### PR DESCRIPTION
This patch addresses the `clippy::unnecessary_unwrap` in the one case where it was occurring. In this case, I think just adding a local exception is the best for this issue, as the way to address this lint in the current form makes the code a little less clear.