### PR TITLE
fix: actually address clippy::unnecessary_unwrap

### DIFF
--- a/src/package_db/http/http.rs
+++ b/src/package_db/http/http.rs
@@ -356,7 +356,7 @@ impl HttpInner {
             (Some(hash), CacheMode::OnlyIfCached) => {
                 self.hash_cache.get(&hash).ok_or_else(|| NotCached.into())
             }
-            _ => Ok(self
+            (_, CacheMode::NoStore) | (None, _) => Ok(self
                 .request(request, cache_mode)?
                 .into_body()
                 .force_seek()?),

--- a/src/package_db/http/http.rs
+++ b/src/package_db/http/http.rs
@@ -342,19 +342,8 @@ impl HttpInner {
         cache_mode: CacheMode,
     ) -> Result<Box<dyn ReadPlusSeek>> {
         let request = http::Request::builder().uri(url.as_str()).body(())?;
-        if maybe_hash.is_some() && cache_mode != CacheMode::NoStore {
-            // Since `maybe_hash` is checked for non-None value in the previous
-            // conditional, clippy complains that you shouldn't need to unwrap.
-            // The resulting code to make clippy happy is less clear than this
-            // code, and using `if let Some(maybe_hash)` with `&&` is currently
-            // unstable. Prefer clarity of code over linting, but if this
-            // logic changes, please try to address this exception.
-            #[allow(clippy::unnecessary_unwrap)]
-            let hash = maybe_hash.unwrap();
-            if cache_mode == CacheMode::OnlyIfCached {
-                self.hash_cache.get(&hash).ok_or_else(||NotCached {}.into())
-            } else {
-                assert!(cache_mode == CacheMode::Default);
+        match (maybe_hash, cache_mode) {
+            (Some(hash), CacheMode::Default) => {
                 Ok(self.hash_cache.get_or_set(&hash, |mut w| {
                     let mut body =
                         self.request(request, CacheMode::NoStore)?.into_body();
@@ -364,11 +353,13 @@ impl HttpInner {
                     Ok(())
                 })?)
             }
-        } else {
-            Ok(self
+            (Some(hash), CacheMode::OnlyIfCached) => {
+                self.hash_cache.get(&hash).ok_or_else(|| NotCached.into())
+            }
+            _ => Ok(self
                 .request(request, cache_mode)?
                 .into_body()
-                .force_seek()?)
+                .force_seek()?),
         }
     }
 }


### PR DESCRIPTION
Follow up to #20, if-let chains can be avoided using a `match` statement, the `assert` can also be removed