### PR TITLE
Update trampolines code

### DIFF
--- a/src/trampolines/windows-trampolines/posy-trampoline/Cargo.lock
+++ b/src/trampolines/windows-trampolines/posy-trampoline/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "embed-manifest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ff574b0b0a794f8995383bb83f21f8f99214422cae791cb48d66da524b00f7"
+checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
 
 [[package]]
 name = "posy-trampoline"
@@ -20,27 +20,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -76,9 +76,9 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "windows-sys"
@@ -97,42 +97,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/src/trampolines/windows-trampolines/posy-trampoline/Cargo.lock
+++ b/src/trampolines/windows-trampolines/posy-trampoline/Cargo.lock
@@ -82,9 +82,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -97,42 +106,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/src/trampolines/windows-trampolines/posy-trampoline/Cargo.toml
+++ b/src/trampolines/windows-trampolines/posy-trampoline/Cargo.toml
@@ -24,7 +24,7 @@ debug = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-windows-sys = { version = "0.42.0", features = [
+windows-sys = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Storage_FileSystem",
@@ -49,8 +49,8 @@ windows-sys = { version = "0.42.0", features = [
 # - Use -Zbuild-std=... -Zbuild-std-features=compiler-builtins-mem, which enables
 #   the mem feature on the built-in builtins.
 #compiler_builtins = { version = "*", features = ["mem"]}
-ufmt-write = "*"
-ufmt = "*"
+ufmt-write = "0.1.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
-embed-manifest = "*"
+embed-manifest = "1.4.0"

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/bin/posy-trampoline-console.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/bin/posy-trampoline-console.rs
@@ -1,4 +1,3 @@
-#![feature(default_alloc_error_handler)]
 #![no_std]
 #![no_main]
 #![windows_subsystem = "console"]

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/bin/posy-trampoline-gui.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/bin/posy-trampoline-gui.rs
@@ -1,4 +1,3 @@
-#![feature(default_alloc_error_handler)]
 #![no_std]
 #![no_main]
 #![windows_subsystem = "windows"]

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/bounce.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/bounce.rs
@@ -14,7 +14,6 @@ use windows_sys::Win32::{
         Environment::{GetCommandLineA, GetEnvironmentVariableA, SetCurrentDirectoryA},
         JobObjects::*,
         Threading::*,
-        WindowsProgramming::INFINITE,
     },
     UI::WindowsAndMessaging::*,
 };

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/diagnostics.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/diagnostics.rs
@@ -60,7 +60,7 @@ impl uWrite for DiagnosticBuffer {
 #[macro_export]
 macro_rules! eprintln {
     ($($tt:tt)*) => {{
-        let mut d = crate::diagnostics::DiagnosticBuffer::new();
+        let mut d = $crate::diagnostics::DiagnosticBuffer::new();
         _ = ufmt::uwriteln!(&mut d, $($tt)*);
         d.display();
     }}

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/helpers.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/helpers.rs
@@ -43,7 +43,7 @@ macro_rules! check {
             );
             let msg = core::slice::from_raw_parts(msg_ptr, size as usize);
             let msg = core::str::from_utf8_unchecked(msg);
-            crate::eprintln!("Error: {} (from {})", msg, stringify!($e));
+            $crate::eprintln!("Error: {} (from {})", msg, stringify!($e));
             ExitProcess(1);
         }
     }

--- a/src/trampolines/windows-trampolines/posy-trampoline/src/runtime.rs
+++ b/src/trampolines/windows-trampolines/posy-trampoline/src/runtime.rs
@@ -36,7 +36,7 @@ unsafe impl GlobalAlloc for SystemAlloc {
 }
 
 #[panic_handler]
-pub extern "C" fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(info: &core::panic::PanicInfo) -> ! {
     if let Some(location) = info.location() {
         let mut msg = "(couldn't format message)";
         if let Some(msg_args) = info.message() {


### PR DESCRIPTION
Update the trampoline code to the latests nightly, use explicit version numbers in `Cargo.toml` instead of `*` and fix clippy warnings.